### PR TITLE
Reorganized tester scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,23 @@
 #    By: vfurmane <marvin@42.fr>                    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/09/08 19:32:49 by vfurmane          #+#    #+#              #
-#    Updated: 2020/09/19 08:50:04 by vfurmane         ###   ########.fr        #
+#    Updated: 2020/09/21 11:58:25 by vfurmane         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRCS		= srcs/*.c
-INCL		= ..
+SRCS		= $(addprefix srcs/, ft_atoi.c ft_bzero.c ft_calloc.c ft_isalnum.c \
+				ft_isalpha.c ft_isascii.c ft_isdigit.c ft_isprint.c \
+				ft_memccpy.c ft_memchr.c ft_memcmp.c ft_memcpy.c ft_memmove.c \
+				ft_memset.c ft_strchr.c ft_strdup.c ft_strjoin.c ft_strlen.c \
+				ft_strncmp.c ft_strnstr.c ft_strrchr.c ft_substr.c \
+				ft_tolower.c ft_toupper.c)
+INCL		=.
 OBJS		= $(SRCS:.c=.o)
 EXEC		= $(OBJS:.o=.out)
 CC			= gcc
 CFLAGS		= -Wall -Wextra -Werror
 RM			= rm -f
+MV			= mv -f
 
 %.o:		%.c
 			$(CC) $(CFLAGS) -c $< -o $@
@@ -25,6 +31,7 @@ RM			= rm -f
 			$(CC) $(CFLAGS) $< -L.. -lft -o $@
 
 all:		$(EXEC)
+			$(MV) srcs/ft_*.out tests/
 
 clean:
 			$(RM) $(OBJS)

--- a/Makefile
+++ b/Makefile
@@ -6,16 +6,11 @@
 #    By: vfurmane <marvin@42.fr>                    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/09/08 19:32:49 by vfurmane          #+#    #+#              #
-#    Updated: 2020/09/21 11:58:25 by vfurmane         ###   ########.fr        #
+#    Updated: 2020/09/21 16:18:53 by vfurmane         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
-SRCS		= $(addprefix srcs/, ft_atoi.c ft_bzero.c ft_calloc.c ft_isalnum.c \
-				ft_isalpha.c ft_isascii.c ft_isdigit.c ft_isprint.c \
-				ft_memccpy.c ft_memchr.c ft_memcmp.c ft_memcpy.c ft_memmove.c \
-				ft_memset.c ft_strchr.c ft_strdup.c ft_strjoin.c ft_strlen.c \
-				ft_strncmp.c ft_strnstr.c ft_strrchr.c ft_substr.c \
-				ft_tolower.c ft_toupper.c)
+SRCS		= $(wildcard srcs/ft_*.c)
 INCL		=.
 OBJS		= $(SRCS:.c=.o)
 EXEC		= $(OBJS:.o=.out)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: vfurmane <marvin@42.fr>                    +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2020/09/08 19:32:49 by vfurmane          #+#    #+#              #
-#    Updated: 2020/09/21 16:18:53 by vfurmane         ###   ########.fr        #
+#    Updated: 2020/09/21 18:15:18 by vfurmane         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -26,7 +26,6 @@ MV			= mv -f
 			$(CC) $(CFLAGS) $< -L.. -lft -o $@
 
 all:		$(EXEC)
-			$(MV) srcs/ft_*.out tests/
 
 clean:
 			$(RM) $(OBJS)

--- a/generate.sh
+++ b/generate.sh
@@ -30,6 +30,7 @@ echo "-------------------${NC}"
 if make 2> /dev/null > /dev/null
 then
 	echo "${GREEN}Compilation succeed${NC}" && echo $'\r'
+	mv srcs/ft_*.out tests/
 else
 	echo "${RED}Compilation failed${NC}" && echo $'\r'
 	make

--- a/generate.sh
+++ b/generate.sh
@@ -27,14 +27,4 @@ fi
 echo "${WHITE}-------------------"
 echo $'Generating tests...'
 echo "-------------------${NC}"
-for filepath in $(find ../srcs -name "ft_*.c")
-do
-	ft_name_c=$(echo "${filepath}" | cut -d / -f 3)
-	echo "${WHITE}Compiling test for ${ft_name_c}${NC}"
-	if gcc -Wall -Wextra -Werror ${filepath} srcs/${ft_name_c} -L${lib_path} -lft -o tests/test_${ft_name_c%.c}
-	then
-		echo "${GREEN}Generated test for ${ft_name_c} successfully.${NC}"
-	else
-		echo "${RED}Failed to generate test for ${ft_name_c} because of a compilation error!${NC}"
-	fi
-done
+make

--- a/generate.sh
+++ b/generate.sh
@@ -27,4 +27,10 @@ fi
 echo "${WHITE}-------------------"
 echo $'Generating tests...'
 echo "-------------------${NC}"
-make
+if make 2> /dev/null > /dev/null
+then
+	echo "${GREEN}Compilation succeed${NC}" && echo $'\r'
+else
+	echo "${RED}Compilation failed${NC}" && echo $'\r'
+	make
+fi

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -19,7 +19,7 @@ then
 	echo "${WHITE}---------------------------------"
 	echo "Testing each function of libft..."
 	echo "---------------------------------${NC}" && echo $'\r'
-	for exe in $(find ./tests -maxdepth 1 -name "test_*")
+	for exe in $(find ./tests -maxdepth 1 -name "ft_*.out")
 	do
 		execute ${exe}
 	done
@@ -31,7 +31,7 @@ else
 	echo "-------------------------------------------${NC}" && echo $'\r'
 	for ft_name in $*
 	do
-		exe="./tests/test_${ft_name}"
+		exe="./tests/ft_${ft_name}.out"
 		if find $exe 2> /dev/null > /dev/null
 		then
 			execute ${exe}


### PR DESCRIPTION
The scripts work as before, but I reorganized some important things so **read well** before approving my commit. In order to work fine, this repository must be cloned into the returned folder (I think it was already the case though).

Now, the `generate.sh` script uses the command `make` instead of compiling the binaries itself.

The `run_tests.sh` script used to execute `test_<name>`. However, I changed the names into `ft_<name>.out`.

Finally, the `Makefile` has a variable `SRCS` that contains all the source files. I just put ones that already exist, so we will have to add more files as we create tests.

> This means that if you didn't create, for example, a `ft_atoi` file, the compilation won't work. So, in local, while you are coding your functions, you should edit the `SRCS` variable as you go.